### PR TITLE
ResetBackbuffer, a couple other fixes

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -931,7 +931,7 @@ static SurfaceFormatMapping XNAToVK_SurfaceFormat[] =
 {
 	/* SurfaceFormat.Color */
 	{
-		VK_FORMAT_B8G8R8A8_UNORM
+		VK_FORMAT_R8G8B8A8_UNORM
 	},
 	/* SurfaceFormat.Bgr565 */
 	{
@@ -6548,12 +6548,7 @@ static uint8_t ChooseSwapSurfaceFormat(
 		}
 	}
 
-	SDL_LogError(
-		SDL_LOG_CATEGORY_APPLICATION,
-		"%s\n",
-		"Desired surface format is unavailable."
-	);
-
+	FNA3D_LogError("Desired surface format is unavailable.");
 	return 0;
 }
 
@@ -7139,6 +7134,12 @@ static uint8_t CreateSwapChain(
 	SurfaceFormatMapping surfaceFormatMapping = XNAToVK_SurfaceFormat[
 		presentationParameters->backBufferFormat
 	];
+
+	if (presentationParameters->backBufferFormat == FNA3D_SURFACEFORMAT_COLOR)
+	{
+		/* FIXME: Is there a better way to handle this...? */
+		surfaceFormatMapping.formatColor = VK_FORMAT_B8G8R8A8_UNORM;
+	}
 
 	if (!QuerySwapChainSupport(
 		renderer,

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -7129,7 +7129,7 @@ static uint8_t CreateSwapChain(
 	uint32_t imageCount, swapChainImageCount, i;
 	VkSwapchainCreateInfoKHR swapChainCreateInfo = { VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR };
 	VkImage *swapChainImages;
-	VkImageViewCreateInfo createInfo;
+	VkImageViewCreateInfo createInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
 	VkImageView swapChainImageView;
 	SurfaceFormatMapping surfaceFormatMapping = XNAToVK_SurfaceFormat[
 		presentationParameters->backBufferFormat
@@ -7234,8 +7234,6 @@ static uint8_t CreateSwapChain(
 
 	for (i = 0; i < swapChainImageCount; i++)
 	{
-		SDL_zero(createInfo);
-		createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
 		createInfo.image = swapChainImages[i];
 		createInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
 		createInfo.format = surfaceFormat.format;

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -869,7 +869,7 @@ static void SubmitPipelineBarrier(
 	FNAVulkanRenderer *renderer
 );
 
-static void CreateFauxBackbuffer(
+static uint8_t CreateFauxBackbuffer(
 	FNAVulkanRenderer *renderer,
 	FNA3D_PresentationParameters *presentationParameters
 );

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -7131,15 +7131,7 @@ static uint8_t CreateSwapChain(
 	VkImage *swapChainImages;
 	VkImageViewCreateInfo createInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
 	VkImageView swapChainImageView;
-	SurfaceFormatMapping surfaceFormatMapping = XNAToVK_SurfaceFormat[
-		presentationParameters->backBufferFormat
-	];
-
-	if (presentationParameters->backBufferFormat == FNA3D_SURFACEFORMAT_COLOR)
-	{
-		/* FIXME: Is there a better way to handle this...? */
-		surfaceFormatMapping.formatColor = VK_FORMAT_B8G8R8A8_UNORM;
-	}
+	SurfaceFormatMapping surfaceFormatMapping = { VK_FORMAT_B8G8R8A8_UNORM };
 
 	if (!QuerySwapChainSupport(
 		renderer,


### PR DESCRIPTION
Factored out the faux backbuffer destruction code from DestroyDevice into its own function, which gets called inside ResetBackbuffer. Also fixed the imageViews segfault on Windows and the SetTextureData2D data length bug.