### PR TITLE
VerifyVertexSampler

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -1651,8 +1651,8 @@ static void BindResources(FNAVulkanRenderer *renderer)
 	vertUniformBufferDescriptorSetNeedsUpdate = (renderer->currentVertUniformBufferDescriptorSet == NULL);
 	fragUniformBufferDescriptorSetNeedsUpdate = (renderer->currentFragUniformBufferDescriptorSet == NULL);
 
-	vertArrayOffset = (renderer->currentSwapChainIndex * MAX_TOTAL_SAMPLERS);
-	fragArrayOffset = (renderer->currentSwapChainIndex * MAX_TOTAL_SAMPLERS) + MAX_VERTEXTEXTURE_SAMPLERS;
+	vertArrayOffset = (renderer->currentSwapChainIndex * MAX_TOTAL_SAMPLERS) + MAX_TEXTURE_SAMPLERS;
+	fragArrayOffset = (renderer->currentSwapChainIndex * MAX_TOTAL_SAMPLERS);
 
 	for (i = 0; i < renderer->currentPipelineLayoutHash.vertSamplerCount; i++)
 	{
@@ -4722,8 +4722,8 @@ void VULKAN_VerifySampler(
 	FNAVulkanRenderer *renderer = (FNAVulkanRenderer*) driverData;
 	VulkanTexture *vulkanTexture = (VulkanTexture*) texture;
 	VkSampler vkSamplerState;
-	uint32_t fragArrayOffset = (renderer->currentSwapChainIndex * MAX_TOTAL_SAMPLERS) + MAX_VERTEXTEXTURE_SAMPLERS;
-	uint32_t textureIndex = fragArrayOffset + index;
+	uint32_t texArrayOffset = (renderer->currentSwapChainIndex * MAX_TOTAL_SAMPLERS);
+	uint32_t textureIndex = texArrayOffset + index;
 	VulkanResourceAccessType nextAccess;
 	ImageMemoryBarrierCreateInfo memoryBarrierCreateInfo;
 
@@ -4821,7 +4821,12 @@ void VULKAN_VerifyVertexSampler(
 	FNA3D_Texture *texture,
 	FNA3D_SamplerState *sampler
 ) {
-	/* TODO */
+	VULKAN_VerifySampler(
+		driverData,
+		MAX_TEXTURE_SAMPLERS + index,
+		texture,
+		sampler
+	);
 }
 
 /* Vertex State */
@@ -5433,7 +5438,7 @@ void VULKAN_AddDisposeTexture(
 ) {
 	FNAVulkanRenderer *renderer = (FNAVulkanRenderer*) driverData;
 	VulkanTexture *vulkanTexture = (VulkanTexture*) texture;
-	uint32_t fragArrayOffset = (renderer->currentSwapChainIndex * MAX_TOTAL_SAMPLERS) + MAX_VERTEXTEXTURE_SAMPLERS;
+	uint32_t texArrayOffset = (renderer->currentSwapChainIndex * MAX_TOTAL_SAMPLERS);
 	uint32_t i, textureIndex;
 
 	for (i = 0; i < renderer->colorAttachmentCount; i++)
@@ -5446,7 +5451,7 @@ void VULKAN_AddDisposeTexture(
 
 	for (i = 0; i < renderer->textureCount; i++)
 	{
-		textureIndex = fragArrayOffset + i;
+		textureIndex = texArrayOffset + i;
 
 		if (vulkanTexture == renderer->textures[textureIndex])
 		{


### PR DESCRIPTION
Vertex textures come after fragment textures in XNA, so I adjusted the offsets accordingly, but beyond that this was very simple. Thanks for doing most of the vertex sampler work ahead of time! 🙂 

Tested with an adapted version of MonoGame's [VertexSampler unit test](https://gist.github.com/TheSpydog/9960f485884a87c9c1cb5e51815b8252).