### PR TITLE
SetTextureDataYUV

### DIFF
--- a/src/FNA3D_Driver.h
+++ b/src/FNA3D_Driver.h
@@ -192,6 +192,41 @@ static inline int32_t IndexSize(FNA3D_IndexElementSize size)
 	return (size == FNA3D_INDEXELEMENTSIZE_16BIT) ? 2 : 4;
 }
 
+static inline int32_t BytesPerRow(
+	int32_t width,
+	FNA3D_SurfaceFormat format
+) {
+	int32_t blocksPerRow = width;
+
+	if (	format == FNA3D_SURFACEFORMAT_DXT1 ||
+		format == FNA3D_SURFACEFORMAT_DXT3 ||
+		format == FNA3D_SURFACEFORMAT_DXT5	)
+	{
+		blocksPerRow = (width + 3) / 4;
+	}
+
+	return blocksPerRow * Texture_GetFormatSize(format);
+}
+
+static inline int32_t BytesPerImage(
+	int32_t width,
+	int32_t height,
+	FNA3D_SurfaceFormat format
+) {
+	int32_t blocksPerRow = width;
+	int32_t blocksPerColumn = height;
+
+	if (	format == FNA3D_SURFACEFORMAT_DXT1 ||
+		format == FNA3D_SURFACEFORMAT_DXT3 ||
+		format == FNA3D_SURFACEFORMAT_DXT5	)
+	{
+		blocksPerRow = (width + 3) / 4;
+		blocksPerColumn = (height + 3) / 4;
+	}
+
+	return blocksPerRow * blocksPerColumn * Texture_GetFormatSize(format);
+}
+
 /* XNA GraphicsDevice Limits */
 
 #define MAX_TEXTURE_SAMPLERS		16

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -468,42 +468,7 @@ const char* FAUX_BLIT_PIXEL_SHADER =
 	"	return Texture.Sample(TextureSampler, texcoord);"
 	"}";
 
-/* Texture Helper Functions */
-
-static inline int32_t BytesPerRow(
-	int32_t width,
-	FNA3D_SurfaceFormat format
-) {
-	int32_t blocksPerRow = width;
-
-	if (	format == FNA3D_SURFACEFORMAT_DXT1 ||
-		format == FNA3D_SURFACEFORMAT_DXT3 ||
-		format == FNA3D_SURFACEFORMAT_DXT5	)
-	{
-		blocksPerRow = (width + 3) / 4;
-	}
-
-	return blocksPerRow * Texture_GetFormatSize(format);
-}
-
-static inline int32_t BytesPerDepthSlice(
-	int32_t width,
-	int32_t height,
-	FNA3D_SurfaceFormat format
-) {
-	int32_t blocksPerRow = width;
-	int32_t blocksPerColumn = height;
-
-	if (	format == FNA3D_SURFACEFORMAT_DXT1 ||
-		format == FNA3D_SURFACEFORMAT_DXT3 ||
-		format == FNA3D_SURFACEFORMAT_DXT5	)
-	{
-		blocksPerRow = (width + 3) / 4;
-		blocksPerColumn = (height + 3) / 4;
-	}
-
-	return blocksPerRow * blocksPerColumn * Texture_GetFormatSize(format);
-}
+/* Helper Functions */
 
 static inline uint32_t CalcSubresource(
 	uint32_t mipLevel,
@@ -3400,7 +3365,7 @@ static void D3D11_SetTextureData3D(
 		&dstBox,
 		data,
 		BytesPerRow(w, format),
-		BytesPerDepthSlice(w, h, format)
+		BytesPerImage(w, h, format)
 	);
 	SDL_UnlockMutex(renderer->ctxLock);
 }
@@ -3450,7 +3415,7 @@ static void D3D11_SetTextureDataCube(
 		&dstBox,
 		data,
 		BytesPerRow(w, format),
-		BytesPerDepthSlice(w, h, format)
+		BytesPerImage(w, h, format)
 	);
 	SDL_UnlockMutex(renderer->ctxLock);
 }

--- a/src/FNA3D_Driver_Metal.c
+++ b/src/FNA3D_Driver_Metal.c
@@ -503,41 +503,6 @@ static MTLPrimitiveType XNAToMTL_Primitive[] =
 
 /* Texture Helper Functions */
 
-static inline int32_t BytesPerRow(
-	int32_t width,
-	FNA3D_SurfaceFormat format
-) {
-	int32_t blocksPerRow = width;
-
-	if (	format == FNA3D_SURFACEFORMAT_DXT1 ||
-		format == FNA3D_SURFACEFORMAT_DXT3 ||
-		format == FNA3D_SURFACEFORMAT_DXT5	)
-	{
-		blocksPerRow = (width + 3) / 4;
-	}
-
-	return blocksPerRow * Texture_GetFormatSize(format);
-}
-
-static inline int32_t BytesPerImage(
-	int32_t width,
-	int32_t height,
-	FNA3D_SurfaceFormat format
-) {
-	int32_t blocksPerRow = width;
-	int32_t blocksPerColumn = height;
-
-	if (	format == FNA3D_SURFACEFORMAT_DXT1 ||
-		format == FNA3D_SURFACEFORMAT_DXT3 ||
-		format == FNA3D_SURFACEFORMAT_DXT5	)
-	{
-		blocksPerRow = (width + 3) / 4;
-		blocksPerColumn = (height + 3) / 4;
-	}
-
-	return blocksPerRow * blocksPerColumn * Texture_GetFormatSize(format);
-}
-
 static inline int32_t ClosestMSAAPower(int32_t value)
 {
 	/* Checking for the highest power of two _after_ than the given int:


### PR DESCRIPTION
1. Moved the `BytesPer*` functions into `FNA3D_Driver.h` since 3/4 of our backends use them.
2. Added SetTextureDataYUV. This is mostly just copy-pasting SetTextureData2D three times in a row with changes for offset / size. Totally cargo-culted on this, I have no idea how the pipeline barriers actually work.

Tested on a video from Dust AET and it works as expected.

There's definitely room for refactoring since the `if (stagingBuffer->resourceAccessType != nextResourceAccessType)` block is copied three times in this function and once in SetTextureData2D. Wanted to see what you thought about extracting that stuff to an external function since it technically already uses another convenience function (`CreateBufferMemoryBarrier`) internally. Would it be weird to have a wrapper for a wrapper?