### PR TITLE
Fix PresentationParameters uninitialized memory crash

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -311,7 +311,8 @@ typedef struct FNAVulkanRenderer
 	VkPhysicalDeviceDriverProperties physicalDeviceDriverProperties;
 	VkDevice logicalDevice;
 
-	FNA3D_PresentationParameters *currentPresentationParameters;
+	FNA3D_PresentInterval presentInterval;
+	void* deviceWindowHandle;
 
 	QueueFamilyIndices queueFamilyIndices;
 	VkQueue graphicsQueue;
@@ -814,8 +815,7 @@ static VulkanTexture* CreateTexture(
 );
 
 static CreateSwapchainResult CreateSwapchain(
-	FNAVulkanRenderer *renderer,
-	FNA3D_PresentationParameters *presentationParameters
+	FNAVulkanRenderer *renderer
 );
 
 static void RecreateSwapchain(
@@ -5666,13 +5666,14 @@ void VULKAN_ResetBackbuffer(
 	FNA3D_PresentationParameters *presentationParameters
 ) {
 	FNAVulkanRenderer *renderer = (FNAVulkanRenderer*) driverData;
-	renderer->currentPresentationParameters = presentationParameters;
+	renderer->presentInterval = presentationParameters->presentationInterval;
+	renderer->deviceWindowHandle = presentationParameters->deviceWindowHandle;
 
 	RecreateSwapchain(renderer);
 	DestroyFauxBackbuffer(renderer);
 	CreateFauxBackbuffer(
 		renderer,
-		renderer->currentPresentationParameters
+		presentationParameters
 	);
 }
 
@@ -7827,7 +7828,7 @@ static void RecreateSwapchain(
 	);
 
 	extent = ChooseSwapExtent(
-		renderer->currentPresentationParameters->deviceWindowHandle,
+		renderer->deviceWindowHandle,
 		swapChainSupportDetails.capabilities
 	);
 
@@ -7837,7 +7838,7 @@ static void RecreateSwapchain(
 	}
 
 	DestroySwapchain(renderer);
-	createSwapchainResult = CreateSwapchain(renderer, renderer->currentPresentationParameters);
+	createSwapchainResult = CreateSwapchain(renderer);
 
 	if (createSwapchainResult == CREATE_SWAPCHAIN_FAIL)
 	{
@@ -7849,8 +7850,7 @@ static void RecreateSwapchain(
 }
 
 static CreateSwapchainResult CreateSwapchain(
-	FNAVulkanRenderer *renderer,
-	FNA3D_PresentationParameters *presentationParameters
+	FNAVulkanRenderer *renderer
 ) {
 	VkResult vulkanResult;
 	SwapChainSupportDetails swapChainSupportDetails;
@@ -7892,7 +7892,7 @@ static CreateSwapchainResult CreateSwapchain(
 
 	if (
 		!ChooseSwapPresentMode(
-			presentationParameters->presentationInterval,
+			renderer->presentInterval,
 			swapChainSupportDetails.presentModes,
 			swapChainSupportDetails.presentModesLength,
 			&presentMode
@@ -7905,7 +7905,7 @@ static CreateSwapchainResult CreateSwapchain(
 	}
 
 	extent = ChooseSwapExtent(
-		presentationParameters->deviceWindowHandle,
+		renderer->deviceWindowHandle,
 		swapChainSupportDetails.capabilities
 	);
 
@@ -8820,7 +8820,8 @@ FNA3D_Device* VULKAN_CreateDevice(
 	renderer->parentDevice = result;
 	result->driverData = (FNA3D_Renderer*) renderer;
 
-	renderer->currentPresentationParameters = presentationParameters;
+	renderer->presentInterval = presentationParameters->presentationInterval;
+	renderer->deviceWindowHandle = presentationParameters->deviceWindowHandle;
 
 	for (i = 0; i < MAX_FRAMES_IN_FLIGHT; i++)
 	{
@@ -8896,12 +8897,8 @@ FNA3D_Device* VULKAN_CreateDevice(
 		return NULL;
 	}
 
-	if (
-		CreateSwapchain(
-			renderer,
-			presentationParameters
-		) != CREATE_SWAPCHAIN_SUCCESS
-	) {
+	if (CreateSwapchain(renderer) != CREATE_SWAPCHAIN_SUCCESS)
+	{
 		FNA3D_LogError("Failed to create swap chain");
 		return NULL;
 	}


### PR DESCRIPTION
After the PresentInterval flibitPatch I noticed that games were crashing with obviously garbage presentation intervals when minimizing + reopening their window. Turns out `presentationParameters` is a pointer to a pinned struct in FNA, so saving it in the renderer led to uninitialized memory crashes since by the time it was referenced all the data it pointed to was garbage. Thankfully only `presentationInterval` and `deviceWindowHandle` were ever used, so I stuffed references to those in the renderer and set them explicitly on device creation and on ResetBackbuffer.