### PR TITLE
Fixes from the XNA Lens Flare sample

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -5616,6 +5616,15 @@ void VULKAN_SetTextureData2D(
 	ImageMemoryBarrierCreateInfo imageBarrierCreateInfo;
 	VkBufferImageCopy imageCopy;
 
+	/* DXT formats require w and h to be multiples of 4 */
+	if (	format == FNA3D_SURFACEFORMAT_DXT1 ||
+		format == FNA3D_SURFACEFORMAT_DXT3 ||
+		format == FNA3D_SURFACEFORMAT_DXT5	)
+	{
+		w = (w + 3) & ~3;
+		h = (h + 3) & ~3;
+	}
+
 	VULKAN_BeginFrame(driverData);
 
 	renderer->vkMapMemory(

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6743,17 +6743,7 @@ void VULKAN_AddDisposeQuery(FNA3D_Renderer *driverData, FNA3D_Query *query)
 	FNAVulkanRenderer *renderer = (FNAVulkanRenderer*) driverData;
 	VulkanQuery *vulkanQuery = (VulkanQuery*) query;
 
-	/* Need to do this between passes */
-	EndPass(renderer);
-
-	renderer->vkCmdResetQueryPool(
-		renderer->drawCommandBuffers[renderer->currentFrame],
-		renderer->queryPool,
-		vulkanQuery->index,
-		1
-	);
-
-	/* Push the now-freed index to the stack */
+	/* Push the now-free index to the stack */
 	renderer->freeQueryIndexStack[vulkanQuery->index] = renderer->freeQueryIndexStackHead;
 	renderer->freeQueryIndexStackHead = vulkanQuery->index;
 
@@ -6764,6 +6754,16 @@ void VULKAN_QueryBegin(FNA3D_Renderer *driverData, FNA3D_Query *query)
 {
 	FNAVulkanRenderer *renderer = (FNAVulkanRenderer*) driverData;
 	VulkanQuery *vulkanQuery = (VulkanQuery*) query;
+
+	/* Need to do this between passes */
+	EndPass(renderer);
+
+	renderer->vkCmdResetQueryPool(
+		renderer->drawCommandBuffers[renderer->currentFrame],
+		renderer->queryPool,
+		vulkanQuery->index,
+		1
+	);
 
 	renderer->vkCmdBeginQuery(
 		renderer->drawCommandBuffers[renderer->currentFrame],


### PR DESCRIPTION
Just a small query validation error fix and proper handling for small DXT mip levels. With these changes the XNA Lens Flare occlusion query sample works beautifully without any validation errors!