### PR TITLE
VS2010 fixes and stb_ds hash_bytes stuff

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -348,40 +348,40 @@ typedef struct FragUniformDescriptorSetData
 
 typedef struct VertexSamplerDescriptorSetDataHashMap
 {
-	size_t key;
+	uint64_t key;
 	VkDescriptorSet descriptorSet;
 	VertexSamplerDescriptorSetData descriptorSetData;
 } VertexSamplerDescriptorSetDataHashMap;
 
 typedef struct FragSamplerDescriptorSetDataHashMap
 {
-	size_t key;
+	uint64_t key;
 	VkDescriptorSet descriptorSet;
 	FragSamplerDescriptorSetData descriptorSetData;
 } FragSamplerDescriptorSetDataHashMap;
 
 typedef struct VertexUniformDescriptorSetDataHashMap
 {
-	size_t key;
+	uint64_t key;
 	VkDescriptorSet descriptorSet;
 	VertexUniformDescriptorSetData descriptorSetData;
 } VertexUniformDescriptorSetDataHashMap;
 
 typedef struct FragUniformDescriptorSetDataHashMap
 {
-	size_t key;
+	uint64_t key;
 	VkDescriptorSet descriptorSet;
 	FragUniformDescriptorSetData descriptorSetData;
 } FragUniformDescriptorSetDataHashMap;
 
 typedef struct DescriptorSetDataHashes
 {
-	size_t   vertexSamplerDescriptorDataHash;
+	uint64_t vertexSamplerDescriptorDataHash;
 	uint32_t vertexSamplerCount;
-	size_t   fragSamplerDescriptorDataHash;
+	uint64_t fragSamplerDescriptorDataHash;
 	uint32_t fragSamplerCount;
-	size_t   vertexUniformDescriptorDataHash;
-	size_t   fragUniformDescriptorDataHash;
+	uint64_t vertexUniformDescriptorDataHash;
+	uint64_t fragUniformDescriptorDataHash;
 } DescriptorSetDataHashes;
 
 /* Command Encoding */
@@ -2188,77 +2188,77 @@ static uint8_t VULKAN_INTERNAL_CreateLogicalDevice(
 
 /* Vulkan: Descriptor Set Logic */
 
-static size_t VULKAN_INTERNAL_HashVertexSamplerDescriptorSetData(
+static uint64_t VULKAN_INTERNAL_HashVertexSamplerDescriptorSetData(
 	VertexSamplerDescriptorSetData *descriptorSetData,
 	uint32_t samplerCount
 ) {
 	uint32_t i;
 	uint64_t next;
-	size_t hash = 0;
+	uint64_t hash = 0;
 
 	for (i = 0; i < samplerCount; i++)
 	{
-		next = (uint64_t) (size_t) descriptorSetData->descriptorImageInfo[i].imageView;
+		next = (uint64_t) descriptorSetData->descriptorImageInfo[i].imageView;
 		hash ^= hash + 0x9e3779b9 + (next << 6) + (next >> 2);
 
-		next = (uint64_t) (size_t) descriptorSetData->descriptorImageInfo[i].sampler;
+		next = (uint64_t) descriptorSetData->descriptorImageInfo[i].sampler;
 		hash ^= hash + 0x9e3779b9 + (next << 6) + (next >> 2);
 	}
 
 	return hash;
 }
 
-static size_t VULKAN_INTERNAL_HashFragSamplerDescriptorSetData(
+static uint64_t VULKAN_INTERNAL_HashFragSamplerDescriptorSetData(
 	FragSamplerDescriptorSetData *descriptorSetData,
 	uint32_t samplerCount
 ) {
 	uint32_t i;
 	uint64_t next;
-	size_t hash = 0;
+	uint64_t hash = 0;
 
 	for (i = 0; i < samplerCount; i++)
 	{
-		next = (uint64_t) (size_t) descriptorSetData->descriptorImageInfo[i].imageView;
+		next = (uint64_t) descriptorSetData->descriptorImageInfo[i].imageView;
 		hash ^= hash + 0x9e3779b9 + (next << 6) + (next >> 2);
 
-		next = (uint64_t) (size_t) descriptorSetData->descriptorImageInfo[i].sampler;
+		next = (uint64_t) descriptorSetData->descriptorImageInfo[i].sampler;
 		hash ^= hash + 0x9e3779b9 + (next << 6) + (next >> 2);
 	}
 
 	return hash;
 }
 
-static size_t VULKAN_INTERNAL_HashVertexUniformDescriptorSetData(
+static uint64_t VULKAN_INTERNAL_HashVertexUniformDescriptorSetData(
 	VertexUniformDescriptorSetData *descriptorSetData
 ) {
 	uint64_t next;
-	size_t hash = 0;
+	uint64_t hash = 0;
 
-	next = (uint64_t) (size_t) descriptorSetData->descriptorBufferInfo.buffer;
+	next = (uint64_t) descriptorSetData->descriptorBufferInfo.buffer;
 	hash ^= hash + 0x9e3779b9 + (next << 6) + (next >> 2);
 
-	next = (uint64_t) (size_t) descriptorSetData->descriptorBufferInfo.offset;
+	next = (uint64_t) descriptorSetData->descriptorBufferInfo.offset;
 	hash ^= hash + 0x9e3779b9 + (next << 6) + (next >> 2);
 
-	next = (uint64_t) (size_t) descriptorSetData->descriptorBufferInfo.range;
+	next = (uint64_t) descriptorSetData->descriptorBufferInfo.range;
 	hash ^= hash + 0x9e3779b9 + (next << 6) + (next >> 2);
 
 	return hash;
 }
 
-static size_t VULKAN_INTERNAL_HashFragUniformDescriptorSetData(
+static uint64_t VULKAN_INTERNAL_HashFragUniformDescriptorSetData(
 	FragUniformDescriptorSetData *descriptorSetData
 ) {
 	uint64_t next;
-	size_t hash = 0;
+	uint64_t hash = 0;
 
-	next = (uint64_t) (size_t) descriptorSetData->descriptorBufferInfo.buffer;
+	next = (uint64_t) descriptorSetData->descriptorBufferInfo.buffer;
 	hash ^= hash + 0x9e3779b9 + (next << 6) + (next >> 2);
 
-	next = (uint64_t) (size_t) descriptorSetData->descriptorBufferInfo.offset;
+	next = (uint64_t) descriptorSetData->descriptorBufferInfo.offset;
 	hash ^= hash + 0x9e3779b9 + (next << 6) + (next >> 2);
 
-	next = (uint64_t) (size_t) descriptorSetData->descriptorBufferInfo.range;
+	next = (uint64_t) descriptorSetData->descriptorBufferInfo.range;
 	hash ^= hash + 0x9e3779b9 + (next << 6) + (next >> 2);
 
 	return hash;
@@ -2548,7 +2548,7 @@ static void VULKAN_INTERNAL_FetchDescriptorSetDataAndOffsets(
 static void VULKAN_INTERNAL_UpdateDescriptorSets(VulkanRenderer *renderer)
 {
 	uint32_t i, j, k;
-	size_t hash;
+	uint64_t hash;
 
 	uint32_t vertexSamplerDescriptorSetCounts[MAX_VERTEXTEXTURE_SAMPLERS] = { 0 };
 	uint32_t fragSamplerDescriptorSetCounts[MAX_TEXTURE_SAMPLERS] = { 0 } ;
@@ -2577,7 +2577,9 @@ static void VULKAN_INTERNAL_UpdateDescriptorSets(VulkanRenderer *renderer)
 
 			if (hmgeti(renderer->vertexSamplerDescriptorSetDataHashMap[i], hash) < 0)
 			{
-				vertexSamplerDescriptorSetStructure = (VertexSamplerDescriptorSetDataHashMap) { hash, NULL_DESC_SET, renderer->vertexSamplerDescriptorSetDatas[i][j] };
+				vertexSamplerDescriptorSetStructure.key = hash;
+				vertexSamplerDescriptorSetStructure.descriptorSet = NULL_DESC_SET;
+				vertexSamplerDescriptorSetStructure.descriptorSetData = renderer->vertexSamplerDescriptorSetDatas[i][j];
 				hmputs(renderer->vertexSamplerDescriptorSetDataHashMap[i], vertexSamplerDescriptorSetStructure);
 
 				vertexSamplerDescriptorSetCounts[i] += 1;
@@ -2594,7 +2596,9 @@ static void VULKAN_INTERNAL_UpdateDescriptorSets(VulkanRenderer *renderer)
 
 			if (hmgeti(renderer->fragSamplerDescriptorSetDataHashMap[i], hash) < 0)
 			{
-				fragSamplerDescriptorSetStructure = (FragSamplerDescriptorSetDataHashMap) { hash, NULL_DESC_SET, renderer->fragSamplerDescriptorSetDatas[i][j] };
+				fragSamplerDescriptorSetStructure.key = hash;
+				fragSamplerDescriptorSetStructure.descriptorSet = NULL_DESC_SET;
+				fragSamplerDescriptorSetStructure.descriptorSetData = renderer->fragSamplerDescriptorSetDatas[i][j];
 				hmputs(renderer->fragSamplerDescriptorSetDataHashMap[i], fragSamplerDescriptorSetStructure);
 
 				fragSamplerDescriptorSetCounts[i] += 1;
@@ -2609,7 +2613,9 @@ static void VULKAN_INTERNAL_UpdateDescriptorSets(VulkanRenderer *renderer)
 
 		if (hmgeti(renderer->vertexUniformDescriptorSetDataHashMap, hash) < 0)
 		{
-			vertexUniformDescriptorSetStructure = (VertexUniformDescriptorSetDataHashMap) { hash, NULL_DESC_SET, renderer->vertexUniformDescriptorSetDatas[i] };
+			vertexUniformDescriptorSetStructure.key = hash;
+			vertexUniformDescriptorSetStructure.descriptorSet = NULL_DESC_SET;
+			vertexUniformDescriptorSetStructure.descriptorSetData = renderer->vertexUniformDescriptorSetDatas[i];
 			hmputs(renderer->vertexUniformDescriptorSetDataHashMap, vertexUniformDescriptorSetStructure);
 
 			vertexUniformDescriptorSetCount += 1;
@@ -2623,7 +2629,9 @@ static void VULKAN_INTERNAL_UpdateDescriptorSets(VulkanRenderer *renderer)
 
 		if (hmgeti(renderer->fragUniformDescriptorSetDataHashMap, hash) < 0)
 		{
-			fragUniformDescriptorSetStructure = (FragUniformDescriptorSetDataHashMap) { hash, NULL_DESC_SET, renderer->fragUniformDescriptorSetDatas[i] };
+			fragUniformDescriptorSetStructure.key = hash;
+			fragUniformDescriptorSetStructure.descriptorSet = NULL_DESC_SET;
+			fragUniformDescriptorSetStructure.descriptorSetData = renderer->fragUniformDescriptorSetDatas[i];
 			hmputs(renderer->fragUniformDescriptorSetDataHashMap, fragUniformDescriptorSetStructure);
 
 			fragUniformDescriptorSetCount += 1;
@@ -3387,7 +3395,7 @@ static void VULKAN_INTERNAL_FlushAndPresent(
 		);
 		presentInfoGGP.sType = VK_STRUCTURE_TYPE_PRESENT_FRAME_TOKEN_GGP;
 		presentInfoGGP.pNext = NULL;
-		presentInfoGGP.frameToken = (uint64_t) (size_t) token;
+		presentInfoGGP.frameToken = (uint64_t) token;
 		presentInfo.pNext = &presentInfoGGP;
 	}
 	else
@@ -4983,8 +4991,8 @@ static VkPipeline VULKAN_INTERNAL_FetchPipeline(VulkanRenderer *renderer)
 	hash.primitiveType = renderer->currentPrimitiveType;
 	hash.sampleMask = renderer->multiSampleMask[0];
 	MOJOSHADER_vkGetBoundShaders(&vertShader, &fragShader);
-	hash.vertShader = (uint64_t) (size_t) vertShader;
-	hash.fragShader = (uint64_t) (size_t) fragShader;
+	hash.vertShader = (uint64_t) vertShader;
+	hash.fragShader = (uint64_t) fragShader;
 	hash.renderPass = renderer->renderPass;
 
 	renderer->currentPipelineLayout = VULKAN_INTERNAL_FetchPipelineLayout(

--- a/src/stb_ds.h
+++ b/src/stb_ds.h
@@ -457,7 +457,11 @@ extern "C" {
 extern void stbds_rand_seed(size_t seed);
 
 // these are the hash functions used internally if you want to test them or use them for other purposes
+#ifdef FNA3D_CHANGE
 extern size_t stbds_hash_bytes(void *p, size_t len, size_t seed);
+#else
+extern uint64_t stbds_hash_bytes(void *p, size_t len, size_t seed);
+#endif
 extern size_t stbds_hash_string(char *str, size_t seed);
 
 // this is a simple string arena allocator, initialize with e.g. 'stbds_string_arena my_arena={0}'.
@@ -1081,7 +1085,11 @@ static size_t stbds_siphash_bytes(void *p, size_t len, size_t seed)
 #endif
 }
 
+#ifdef FNA3D_CHANGE
 size_t stbds_hash_bytes(void *p, size_t len, size_t seed)
+#else
+uint64_t stbds_hash_bytes(void *p, size_t len, size_t seed)
+#endif
 {
 #ifdef STBDS_SIPHASH_2_4
   return stbds_siphash_bytes(p,len,seed);
@@ -1144,7 +1152,9 @@ size_t stbds_hash_bytes(void *p, size_t len, size_t seed)
     //   15.58ms   //   14.79ms   //   15.52ms : 200,000 inserts creating 200K table with varying key spacing
 
     return (((size_t) hash << 16 << 16) | hash) ^ seed;
-  } else if (len == 8 && sizeof(size_t) == 8) {
+  }
+#ifdef FNA3D_CHANGE
+  else if (len == 8 && sizeof(size_t) == 8) {
     size_t hash = d[0] | (d[1] << 8) | (d[2] << 16) | (d[3] << 24);
     hash |= (size_t) (d[4] | (d[5] << 8) | (d[6] << 16) | (d[7] << 24)) << 16 << 16; // avoid warning if size_t == 4
     hash ^= seed;
@@ -1158,7 +1168,12 @@ size_t stbds_hash_bytes(void *p, size_t len, size_t seed)
     hash += (hash << 31);
     hash = (~hash) + (hash << 18);
     return hash;
-  } else {
+#else
+  else if (len == 8) {
+    return *((uint64_t*) p);
+  }
+#endif
+  else {
     return stbds_siphash_bytes(p,len,seed);
   }
 #endif


### PR DESCRIPTION
This is pretty ugly and generates a fair number of size_t <-> int32/64 conversion warnings, but it's functional at least. The direct path through stbds_hash_bytes doesn't seem to have improved much of anything, but you can verify that. I very well may have screwed something up with that.